### PR TITLE
Re-introduce Shared Display Reference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
  "embedded-graphics",
  "embedded-graphics-simulator",
  "heapless",
- "shared-display-core 0.1.0 (git+https://github.com/paulmoseskailer/shared-display.git)",
+ "shared-display-core 0.1.0 (git+https://github.com/paulmoseskailer/shared-display.git?branch=16-bit-color-support)",
  "static_cell",
  "tokio",
 ]
@@ -701,7 +701,15 @@ dependencies = [
 [[package]]
 name = "shared-display-core"
 version = "0.1.0"
-source = "git+https://github.com/paulmoseskailer/shared-display.git#584e7964d95190a50a7b3d37f8b3a3f44df131a2"
+source = "git+https://github.com/paulmoseskailer/shared-display.git?branch=16-bit-color-support#d65f45798d72ae63e10e3c9bc05d03354d7c8b31"
+dependencies = [
+ "embedded-graphics",
+]
+
+[[package]]
+name = "shared-display-core"
+version = "0.1.0"
+source = "git+https://github.com/paulmoseskailer/shared-display.git#35792b2a8404773b5d52ff1d924ef2578fe93f76"
 dependencies = [
  "embedded-graphics",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 members = ["core"]
 
 [dependencies]
-shared-display-core = { git = "https://github.com/paulmoseskailer/shared-display.git", version = "0.1.0", default-features = false }
+shared-display-core = { git = "https://github.com/paulmoseskailer/shared-display.git", branch = "16-bit-color-support", version = "0.1.0", default-features = false }
 embassy-sync = "0.6.2"
 embedded-graphics = { version = "0.8.1", default-features = false, features = ["async_draw"] } 
 heapless = "0.8.0"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -69,7 +69,7 @@ where
 
         let pixels_per_buffer_el =
             (self.parent_size.width * self.parent_size.height) as usize / self.buffer_len;
-        if self.parent_size.width % pixels_per_buffer_el as u32 != 0 {
+        if pixels_per_buffer_el > 0 && self.parent_size.width % pixels_per_buffer_el as u32 != 0 {
             return Err(PartitioningError::BufferPixelMismatch);
         }
 
@@ -136,7 +136,7 @@ pub trait SharableBufferedDisplay: DrawTarget {
         let parent_size = self.bounding_box().size;
         let buffer_len = self.get_buffer().len();
         let pixels_per_buffer_el = (parent_size.width * parent_size.height) as usize / buffer_len;
-        if parent_size.width % pixels_per_buffer_el as u32 != 0 {
+        if pixels_per_buffer_el > 0 && parent_size.width % pixels_per_buffer_el as u32 != 0 {
             return Err(PartitioningError::BufferPixelMismatch);
         }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -107,23 +107,14 @@ where
     }
 }
 
-pub struct PixelInBuffer {
-    pub start_index: usize,
-    pub width_in_buffer_elements: usize,
-}
-
 pub trait SharableBufferedDisplay: DrawTarget {
     type BufferElement;
 
     fn get_buffer(&mut self) -> &mut [Self::BufferElement];
 
-    fn calculate_buffer_index(point: Point, parent_size: Size) -> PixelInBuffer;
+    fn calculate_buffer_index(point: Point, parent_size: Size) -> usize;
 
-    fn set_ith_buffer_element_for_pixel(
-        buffer: &mut Self::BufferElement,
-        pixel: Pixel<Self::Color>,
-        i: usize,
-    );
+    fn set_pixel(buffer: &mut Self::BufferElement, pixel: Pixel<Self::Color>);
 
     fn new_partition(
         &mut self,
@@ -196,17 +187,7 @@ where
             .for_each(|p| {
                 let buffer_index = D::calculate_buffer_index(p.0, self.parent_size);
                 if self.contains(p.0) {
-                    for offset in 0..(buffer_index.width_in_buffer_elements) {
-                        let index = buffer_index.start_index + offset;
-                        // TODO maybe panic if index out of range? seems like a severe error
-                        if index < self.buffer_len {
-                            D::set_ith_buffer_element_for_pixel(
-                                &mut whole_buffer[index],
-                                p,
-                                offset,
-                            );
-                        }
-                    }
+                    D::set_pixel(&mut whole_buffer[buffer_index], p);
                 }
             });
         Ok(())

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -119,7 +119,11 @@ pub trait SharableBufferedDisplay: DrawTarget {
 
     fn calculate_buffer_index(point: Point, parent_size: Size) -> PixelInBuffer;
 
-    fn set_pixel(buffer: &mut Self::BufferElement, pixel: Pixel<Self::Color>);
+    fn set_ith_buffer_element_for_pixel(
+        buffer: &mut Self::BufferElement,
+        pixel: Pixel<Self::Color>,
+        i: usize,
+    );
 
     fn new_partition(
         &mut self,
@@ -196,7 +200,11 @@ where
                         let index = buffer_index.start_index + offset;
                         // TODO maybe panic if index out of range? seems like a severe error
                         if index < self.buffer_len {
-                            D::set_pixel(&mut whole_buffer[index], p);
+                            D::set_ith_buffer_element_for_pixel(
+                                &mut whole_buffer[index],
+                                p,
+                                offset,
+                            );
                         }
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 #![feature(async_fn_traits)]
 
 pub mod toolkit;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,4 @@
 #![feature(async_fn_traits)]
 
 pub mod toolkit;
+pub use shared_display_core::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![feature(async_fn_traits)]
 
+pub mod shared_display_ref;
 pub mod toolkit;
 pub use shared_display_core::*;

--- a/src/shared_display_ref.rs
+++ b/src/shared_display_ref.rs
@@ -1,0 +1,104 @@
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+
+use embassy_sync::mutex::Mutex;
+
+use embedded_graphics::{
+    Pixel,
+    draw_target::{DrawTarget, DrawTargetExt},
+    geometry::{OriginDimensions, Point},
+    prelude::{PixelColor, Size},
+    primitives::Rectangle,
+};
+
+pub struct SharedDisplayReference<D: DrawTarget + OriginDimensions + 'static> {
+    display_ref: &'static Mutex<CriticalSectionRawMutex, Option<D>>,
+
+    area: Rectangle,
+}
+
+impl<C: PixelColor, E, D: DrawTarget<Color = C, Error = E> + OriginDimensions + 'static>
+    SharedDisplayReference<D>
+{
+    pub fn from_rectangle(
+        display: &'static Mutex<CriticalSectionRawMutex, Option<D>>,
+
+        rect: Rectangle,
+    ) -> Self {
+        SharedDisplayReference {
+            display_ref: display,
+
+            area: rect,
+        }
+    }
+}
+
+impl<D: DrawTarget + OriginDimensions> OriginDimensions for SharedDisplayReference<D> {
+    fn size(&self) -> Size {
+        self.area.size
+    }
+}
+
+impl<C: PixelColor, E, D: DrawTarget<Color = C, Error = E> + OriginDimensions> DrawTarget
+    for SharedDisplayReference<D>
+{
+    type Color = C;
+
+    type Error = E;
+
+    async fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        let mut guard = self.display_ref.lock().await;
+
+        let disp = guard.as_mut().unwrap();
+
+        disp.clipped(&self.area).draw_iter(pixels).await
+    }
+
+    async fn clear(&mut self, color: Self::Color) -> Result<(), Self::Error> {
+        let mut guard = self.display_ref.lock().await;
+
+        let disp = guard.as_mut().unwrap();
+
+        disp.clipped(&self.area).fill_solid(&self.area, color).await
+    }
+}
+
+pub async fn split_vertically<D>(
+    display: &'static Mutex<CriticalSectionRawMutex, Option<D>>,
+) -> (SharedDisplayReference<D>, SharedDisplayReference<D>)
+where
+    D: DrawTarget + OriginDimensions,
+{
+    let (top_left, size) = {
+        let guard = display.lock().await;
+
+        let disp = guard.as_ref().unwrap();
+
+        let bounding_box = disp.bounding_box();
+
+        (bounding_box.top_left, bounding_box.size)
+    };
+
+    let split_size = Size {
+        width: size.width / 2,
+
+        height: size.height,
+    };
+
+    (
+        SharedDisplayReference::from_rectangle(display, Rectangle::new(top_left, split_size)),
+        SharedDisplayReference::from_rectangle(
+            display,
+            Rectangle::new(
+                Point {
+                    x: top_left.x + size.width as i32 / 2,
+
+                    y: top_left.y,
+                },
+                split_size,
+            ),
+        ),
+    )
+}

--- a/src/toolkit.rs
+++ b/src/toolkit.rs
@@ -1,3 +1,5 @@
+extern crate alloc;
+use alloc::boxed::Box;
 use core::future::Future;
 use core::pin::Pin;
 use embassy_executor::Spawner;


### PR DESCRIPTION
Re-introduces the original screen-sharing solution of simply taking a mutex-locked reference to the real display. Mainly used to compare performance to the shared buffer solution.

Also fixes some bugs.