### PR TITLE
Only flush dirty area

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,6 @@ dependencies = [
 [[package]]
 name = "embedded-graphics-simulator"
 version = "0.7.0"
-source = "git+https://github.com/paulmoseskailer/simulator.git#d1530172e044b006ea93aa565af6f5990fee3c87"
 dependencies = [
  "base64",
  "embedded-graphics",
@@ -262,7 +261,7 @@ dependencies = [
  "maybe-async",
  "ouroboros",
  "sdl2",
- "shared-display-core 0.1.0 (git+https://github.com/paulmoseskailer/shared-display.git)",
+ "shared-display-core 0.1.0 (git+https://github.com/paulmoseskailer/shared-display.git?branch=only-flush-dirty)",
 ]
 
 [[package]]
@@ -686,7 +685,7 @@ dependencies = [
  "embedded-graphics",
  "embedded-graphics-simulator",
  "heapless",
- "shared-display-core 0.1.0",
+ "shared-display-core 0.1.0 (git+https://github.com/paulmoseskailer/shared-display.git?branch=only-flush-dirty)",
  "static_cell",
  "tokio",
 ]
@@ -702,8 +701,9 @@ dependencies = [
 [[package]]
 name = "shared-display-core"
 version = "0.1.0"
-source = "git+https://github.com/paulmoseskailer/shared-display.git#35792b2a8404773b5d52ff1d924ef2578fe93f76"
+source = "git+https://github.com/paulmoseskailer/shared-display.git?branch=only-flush-dirty#f153563ecb3b2c91274e3e1d4c7e8b5a98b72d0c"
 dependencies = [
+ "embassy-sync",
  "embedded-graphics",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
  "embedded-graphics",
  "embedded-graphics-simulator",
  "heapless",
- "shared-display-core 0.1.0 (git+https://github.com/paulmoseskailer/shared-display.git)",
+ "shared-display-core 0.1.0",
  "static_cell",
  "tokio",
 ]
@@ -695,6 +695,7 @@ dependencies = [
 name = "shared-display-core"
 version = "0.1.0"
 dependencies = [
+ "embassy-sync",
  "embedded-graphics",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 members = ["core"]
 
 [dependencies]
-shared-display-core = { git = "https://github.com/paulmoseskailer/shared-display.git", version = "0.1.0", default-features = false }
+shared-display-core = { git = "https://github.com/paulmoseskailer/shared-display.git", branch = "only-flush-dirty", version = "0.1.0", default-features = false }
 embassy-sync = "0.6.2"
 embedded-graphics = { version = "0.8.1", default-features = false, features = ["async_draw"] } 
 heapless = "0.8.0"
@@ -18,7 +18,7 @@ static_cell = "2.1.0"
 [dev-dependencies]
 tokio = {version = "1.44.0", features = ["full"]}
 # for examples
-embedded-graphics-simulator = { git = "https://github.com/paulmoseskailer/simulator.git", version = "0.7.0", default-features=false, features = ["with-sdl", "async_draw"]}
+embedded-graphics-simulator = { path = "../simulator-paul/", version = "0.7.0", default-features=false, features = ["with-sdl", "async_draw"]}
 embassy-time = {version = "0.4.0", features = ["std"]}
 embassy-sync = {version = "0.6.2", features = ["std"]}
 embassy-executor = {version = "0.7.0", features = ["arch-std", "executor-thread"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ embedded-graphics = { version = "0.8.1", default-features = false, features = ["
 heapless = "0.8.0"
 embassy-time = {version = "0.4.0"}
 embassy-executor = {version = "0.7.0"}
+static_cell = "2.1.0"
 
 [dev-dependencies]
 tokio = {version = "1.44.0", features = ["full"]}
@@ -21,7 +22,6 @@ embedded-graphics-simulator = { git = "https://github.com/paulmoseskailer/simula
 embassy-time = {version = "0.4.0", features = ["std"]}
 embassy-sync = {version = "0.6.2", features = ["std"]}
 embassy-executor = {version = "0.7.0", features = ["arch-std", "executor-thread"]}
-static_cell = "2.1.0"
 
 [patch.crates-io]
 embedded-graphics = {git = "https://github.com/paulmoseskailer/embedded-graphics.git"}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Enabling concurrent screen-sharing applications with embedded Rust.
 
-## How to Run
+## How to Use
 
 See `examples` folder.
 
@@ -15,9 +15,8 @@ cargo run --example hello_world
 - [x] `SharableBufferedDisplay` Trait
 - [x] basic toolkit functionality for easy development
 - [ ] handle resizing of partitions at runtime
-- [ ] `SharableNoBufferDisplay` Trait
 - [ ] integrate buffer compression
-- [ ] submit PRs for dependencies: `embedded-graphics`, `simulator`
+- [ ] submit PRs for dependencies: `embedded-graphics`, `simulator`(, `ssd1351`)
 
 ## Some Notes on Design Decisions
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2024"
 
 [dependencies]
 embedded-graphics = { version = "0.8.1", default-features = false, features = ["async_draw"] } 
+embassy-sync = "0.6.2"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,6 +1,9 @@
 #![no_std]
 #![allow(async_fn_in_trait)]
 
+use core::sync::atomic::{AtomicBool, Ordering};
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex};
+use embedded_graphics::prelude::ContainsPoint;
 use embedded_graphics::{
     Pixel,
     draw_target::DrawTarget,
@@ -23,12 +26,38 @@ pub enum PartitioningError {
     ExistingNotFound,
 }
 
+pub struct DrawTracker {
+    is_dirty: AtomicBool,
+    pub dirty_area: Mutex<CriticalSectionRawMutex, Rectangle>,
+}
+
+impl DrawTracker {
+    pub const fn new() -> Self {
+        Self {
+            is_dirty: AtomicBool::new(false),
+            dirty_area: Mutex::new(Rectangle::new_at_origin(Size::new_equal(0))),
+        }
+    }
+}
+
 pub struct DisplayPartition<B, D: ?Sized> {
     pub buffer: *mut B,
     buffer_len: usize,
     pub parent_size: Size,
     pub area: Rectangle,
     _display: core::marker::PhantomData<D>,
+
+    draw_tracker: &'static DrawTracker,
+}
+
+impl<C, B, D> ContainsPoint for DisplayPartition<B, D>
+where
+    C: PixelColor,
+    D: SharableBufferedDisplay<BufferElement = B, Color = C> + ?Sized,
+{
+    fn contains(&self, p: Point) -> bool {
+        self.area.contains(p)
+    }
 }
 
 impl<C, B, D> DisplayPartition<B, D>
@@ -36,18 +65,20 @@ where
     C: PixelColor,
     D: SharableBufferedDisplay<BufferElement = B, Color = C> + ?Sized,
 {
-    pub fn new(buffer: &mut [B], parent_size: Size, area: Rectangle) -> DisplayPartition<B, D> {
+    pub fn new(
+        buffer: &mut [B],
+        parent_size: Size,
+        area: Rectangle,
+        draw_tracker: &'static DrawTracker,
+    ) -> DisplayPartition<B, D> {
         DisplayPartition {
             buffer: buffer.as_mut_ptr(),
             parent_size,
             buffer_len: buffer.len(),
             area,
             _display: core::marker::PhantomData,
+            draw_tracker,
         }
-    }
-
-    fn contains(&self, p: Point) -> bool {
-        self.area.contains(p)
     }
 
     pub fn split_vertically(
@@ -81,6 +112,7 @@ where
                 },
                 self.parent_size,
                 left_area,
+                self.draw_tracker,
             ),
             DisplayPartition::new(
                 unsafe {
@@ -89,6 +121,7 @@ where
                 },
                 self.parent_size,
                 right_area,
+                self.draw_tracker,
             ),
         ))
     }
@@ -119,6 +152,7 @@ pub trait SharableBufferedDisplay: DrawTarget {
     fn new_partition(
         &mut self,
         area: Rectangle,
+        draw_tracker: &'static DrawTracker,
     ) -> Result<DisplayPartition<Self::BufferElement, Self>, PartitioningError> {
         if area.size.width < 8 {
             return Err(PartitioningError::PartitionTooSmall);
@@ -135,34 +169,12 @@ pub trait SharableBufferedDisplay: DrawTarget {
             return Err(PartitioningError::PartitionBadWidth);
         }
 
-        Ok(DisplayPartition::new(self.get_buffer(), parent_size, area))
-    }
-
-    fn split_buffer_vertically(
-        &mut self,
-    ) -> Result<
-        (
-            DisplayPartition<Self::BufferElement, Self>,
-            DisplayPartition<Self::BufferElement, Self>,
-        ),
-        PartitioningError,
-    > {
-        let parent_size = self.bounding_box().size;
-
-        // ensure no bytes are split in half by rounding to a split of width multiple of 8
-        let left_area_width = (parent_size.width / 2) + 7 & !7;
-        let left_area = Rectangle::new(
-            self.bounding_box().top_left,
-            Size::new(left_area_width, parent_size.height),
-        );
-        let right_area = Rectangle::new(
-            self.bounding_box().top_left + Point::new(left_area_width.try_into().unwrap(), 0),
-            Size::new(parent_size.width - left_area_width, parent_size.height),
-        );
-
-        let left = self.new_partition(left_area)?;
-        let right = self.new_partition(right_area)?;
-        Ok((left, right))
+        Ok(DisplayPartition::new(
+            self.get_buffer(),
+            parent_size,
+            area,
+            draw_tracker,
+        ))
     }
 }
 
@@ -177,6 +189,7 @@ where
     where
         I: ::core::iter::IntoIterator<Item = Pixel<Self::Color>>,
     {
+        let mut dirty_area: Option<Rectangle> = None;
         let whole_buffer: &mut [B] =
             // Safety: we check that every index is within our owned slice
             unsafe { core::slice::from_raw_parts_mut(self.buffer, self.buffer_len) };
@@ -188,14 +201,29 @@ where
                 let buffer_index = D::calculate_buffer_index(p.0, self.parent_size);
                 if self.contains(p.0) {
                     D::set_pixel(&mut whole_buffer[buffer_index], p);
+
+                    dirty_area = match dirty_area {
+                        None => Some(Rectangle::with_center(p.0, Size::default())),
+                        Some(previous_area) => Some(
+                            previous_area.envelope(&Rectangle::with_center(p.0, Size::default())),
+                        ),
+                    };
                 }
             });
+        if let Some(dirty_area) = dirty_area {
+            self.draw_tracker.is_dirty.store(true, Ordering::Relaxed);
+            let mut guard = self.draw_tracker.dirty_area.lock().await;
+            *guard = (*guard).envelope(&dirty_area);
+        }
         Ok(())
     }
 
     // Make sure to remove the offset from the Rectangle to be cleared,
     // draw_iter adds it again
     async fn clear(&mut self, color: Self::Color) -> Result<(), Self::Error> {
+        self.draw_tracker.is_dirty.store(true, Ordering::Relaxed);
+        *self.draw_tracker.dirty_area.lock().await = self.area;
+
         self.fill_solid(&(Rectangle::new(Point::new(0, 0), self.area.size)), color)
             .await
     }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -38,6 +38,17 @@ impl DrawTracker {
             dirty_area: Mutex::new(Rectangle::new_at_origin(Size::new_equal(0))),
         }
     }
+
+    pub async fn take_dirty_area(&self) -> Option<Rectangle> {
+        if self.is_dirty.swap(false, Ordering::Acquire) {
+            let mut guard = self.dirty_area.lock().await;
+            let result = guard.clone();
+            *guard = Rectangle::new_at_origin(Size::new_equal(0));
+            Some(result)
+        } else {
+            None
+        }
+    }
 }
 
 pub struct DisplayPartition<B, D: ?Sized> {

--- a/examples/dynamic_split.rs
+++ b/examples/dynamic_split.rs
@@ -9,12 +9,10 @@ use embedded_graphics::{
 use embedded_graphics_simulator::{
     BinaryColorTheme, OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window,
 };
-use shared_display::toolkit::{FlushResult, SharedDisplay, launch_inside_app};
+use shared_display::toolkit::{FlushResult, SharedDisplay, launch_app_in_app};
 use shared_display_core::DisplayPartition;
-use static_cell::StaticCell;
 
 type DisplayType = SimulatorDisplay<BinaryColor>;
-static SPAWNER: StaticCell<Spawner> = StaticCell::new();
 
 fn init_simulator_display() -> (DisplayType, Window) {
     let output_settings = OutputSettingsBuilder::new()
@@ -28,8 +26,8 @@ fn init_simulator_display() -> (DisplayType, Window) {
 
 async fn recursive_split_app(
     recursion_level: u8,
-    spawner: &'static Spawner,
     mut display: DisplayPartition<BinaryColor, DisplayType>,
+    spawner: &'static Spawner,
 ) -> () {
     let max_x: i32 = (display.bounding_box().size.width - 1).try_into().unwrap();
     let max_y: i32 = (display.bounding_box().size.height - 1).try_into().unwrap();
@@ -62,15 +60,15 @@ async fn recursive_split_app(
     // recursive case
     let (left_display, right_display) = display.split_vertically().unwrap();
     let new_recursion_level = recursion_level - 1;
-    launch_inside_app(
+    launch_app_in_app(
         spawner,
-        move |d| recursive_split_app(new_recursion_level, spawner, d),
+        move |d| recursive_split_app(new_recursion_level, d, spawner),
         left_display,
     )
     .await;
-    launch_inside_app(
+    launch_app_in_app(
         spawner,
-        move |d| recursive_split_app(new_recursion_level, spawner, d),
+        move |d| recursive_split_app(new_recursion_level, d, spawner),
         right_display,
     )
     .await;
@@ -79,25 +77,22 @@ async fn recursive_split_app(
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
     let (display, mut window) = init_simulator_display();
-    let spawner_ref: &'static Spawner = SPAWNER.init(spawner);
 
-    let mut shared_display: SharedDisplay<DisplayType> = SharedDisplay::new(display).await;
+    let mut shared_display: SharedDisplay<DisplayType> = SharedDisplay::new(display, spawner).await;
 
     let half_size = Size::new(64, 64);
     let left_rect = Rectangle::new(Point::new(0, 0), half_size);
     let right_rect = Rectangle::new(Point::new(64, 0), half_size);
     shared_display
-        .launch_new_app(
-            spawner_ref,
-            move |disp| recursive_split_app(2, spawner_ref, disp),
+        .launch_new_recursive_app(
+            move |disp, spawner| recursive_split_app(2, disp, spawner),
             left_rect,
         )
         .await
         .unwrap();
     shared_display
-        .launch_new_app(
-            spawner_ref,
-            move |disp| recursive_split_app(1, spawner_ref, disp),
+        .launch_new_recursive_app(
+            move |disp, spawner| recursive_split_app(1, disp, spawner),
             right_rect,
         )
         .await

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -13,11 +13,8 @@ use embedded_graphics_simulator::{
 };
 use shared_display::toolkit::{FlushResult, SharedDisplay};
 use shared_display_core::DisplayPartition;
-use static_cell::StaticCell;
 
 type DisplayType = SimulatorDisplay<BinaryColor>;
-
-static SPAWNER: StaticCell<Spawner> = StaticCell::new();
 
 fn init_simulator_display() -> (DisplayType, Window) {
     let output_settings = OutputSettingsBuilder::new()
@@ -77,20 +74,18 @@ async fn line_app(mut display: DisplayPartition<BinaryColor, DisplayType>) -> ()
 
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
-    let spawner = SPAWNER.init(spawner);
-
     let (display, mut window) = init_simulator_display();
-    let mut shared_display: SharedDisplay<DisplayType> = SharedDisplay::new(display).await;
+    let mut shared_display: SharedDisplay<DisplayType> = SharedDisplay::new(display, spawner).await;
 
     let right_rect = Rectangle::new(Point::new(64, 0), Size::new(64, 64));
     shared_display
-        .launch_new_app(spawner, line_app, right_rect)
+        .launch_new_app(line_app, right_rect)
         .await
         .unwrap();
 
     let left_rect = Rectangle::new(Point::new(0, 0), Size::new(64, 64));
     shared_display
-        .launch_new_app(spawner, text_app, left_rect)
+        .launch_new_app(text_app, left_rect)
         .await
         .unwrap();
 

--- a/examples/resize_app.rs
+++ b/examples/resize_app.rs
@@ -13,11 +13,8 @@ use embedded_graphics_simulator::{
 };
 use shared_display::toolkit::{self, FlushResult, SharedDisplay};
 use shared_display_core::DisplayPartition;
-use static_cell::StaticCell;
 
 type DisplayType = SimulatorDisplay<BinaryColor>;
-
-static SPAWNER: StaticCell<Spawner> = StaticCell::new();
 
 fn init_simulator_display() -> (DisplayType, Window) {
     let output_settings = OutputSettingsBuilder::new()
@@ -91,20 +88,18 @@ async fn line_app(mut display: DisplayPartition<BinaryColor, DisplayType>) -> ()
 
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
-    let spawner = SPAWNER.init(spawner);
-
     let (display, mut window) = init_simulator_display();
-    let mut shared_display: SharedDisplay<DisplayType> = SharedDisplay::new(display).await;
+    let mut shared_display: SharedDisplay<DisplayType> = SharedDisplay::new(display, spawner).await;
 
     let right_rect = Rectangle::new(Point::new(64, 0), Size::new(64, 64));
     shared_display
-        .launch_new_app(spawner, line_app, right_rect)
+        .launch_new_app(line_app, right_rect)
         .await
         .unwrap();
 
     let left_rect = Rectangle::new(Point::new(0, 0), Size::new(64, 64));
     shared_display
-        .launch_new_app(spawner, text_app, left_rect)
+        .launch_new_app(text_app, left_rect)
         .await
         .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![no_std]
 #![feature(async_fn_traits)]
 
 pub mod shared_display_ref;

--- a/src/toolkit.rs
+++ b/src/toolkit.rs
@@ -185,9 +185,11 @@ where
         loop {
             // TODO: only flush if any partition has updates
             for &draw_tracker in self.draw_trackers.iter() {
-                let area = draw_tracker.dirty_area.lock().await.size;
-                println!("draw_tracker has size {}x{}", area.width, area.height);
+                if let Some(area) = draw_tracker.take_dirty_area().await {
+                    println!("draw_tracker has area {:?}", area);
+                }
             }
+            println!("");
             match flush(&mut *self.real_display.lock().await).await {
                 FlushResult::Continue => {}
                 FlushResult::Abort => {


### PR DESCRIPTION
Adds a DrawTracker object for every DisplayPartition that records which area "is dirty", i.e. has been drawn to.
When flushing, only the dirty area needs to be flushed. When drawing, enlarges the dirty area to include every drawn pixel.
Flushes every partition's dirty area individually.

- [ ] update required flush method to flush rectangle
- [ ] add tests