### PR TITLE
Remove atomic swap calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,6 @@ dependencies = [
 [[package]]
 name = "embedded-graphics-simulator"
 version = "0.7.0"
-source = "git+https://github.com/paulmoseskailer/simulator.git#d1530172e044b006ea93aa565af6f5990fee3c87"
 dependencies = [
  "base64",
  "embedded-graphics",
@@ -262,7 +261,7 @@ dependencies = [
  "maybe-async",
  "ouroboros",
  "sdl2",
- "shared-display-core 0.1.0 (git+https://github.com/paulmoseskailer/shared-display.git)",
+ "shared-display-core",
 ]
 
 [[package]]
@@ -686,7 +685,7 @@ dependencies = [
  "embedded-graphics",
  "embedded-graphics-simulator",
  "heapless",
- "shared-display-core 0.1.0 (git+https://github.com/paulmoseskailer/shared-display.git)",
+ "shared-display-core",
  "static_cell",
  "tokio",
 ]
@@ -696,14 +695,6 @@ name = "shared-display-core"
 version = "0.1.0"
 dependencies = [
  "embassy-sync",
- "embedded-graphics",
-]
-
-[[package]]
-name = "shared-display-core"
-version = "0.1.0"
-source = "git+https://github.com/paulmoseskailer/shared-display.git#ddbf43a324f49c33345ab999a2a5cef3fb8485a7"
-dependencies = [
  "embedded-graphics",
 ]
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -234,7 +234,9 @@ where
     // draw_iter adds it again
     async fn clear(&mut self, color: Self::Color) -> Result<(), Self::Error> {
         self.draw_tracker.is_dirty.store(true, Ordering::Relaxed);
-        *self.draw_tracker.dirty_area.lock().await = Some(self.area);
+        {
+            *self.draw_tracker.dirty_area.lock().await = Some(self.area);
+        }
 
         self.fill_solid(&(Rectangle::new(Point::new(0, 0), self.area.size)), color)
             .await

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -40,10 +40,11 @@ impl DrawTracker {
     }
 
     pub async fn take_dirty_area(&self) -> Option<Rectangle> {
-        if self.is_dirty.swap(false, Ordering::Acquire) {
+        if self.is_dirty.load(Ordering::Acquire) {
             let mut guard = self.dirty_area.lock().await;
             let result = guard.clone().unwrap();
             *guard = None;
+            self.is_dirty.store(false, Ordering::Release);
             Some(result)
         } else {
             None


### PR DESCRIPTION
Replaces the atomic swap function call for `DrawTracker.is_dirty` with a load and possibly a store.
This is necessary to support embedded targets that support atomic load and store, but no swap (like the Raspberry Pi Pico W).

All other operations on that variable are stores. In the worst case we load the value, someone else writes true while we get the dirty area and then we override writing false. This could result in drawing operations between the two operations going unnoticed and having to wait until the next flush. 