### PR TITLE
Efficient flush

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,7 +3,7 @@
 
 use core::sync::atomic::{AtomicBool, Ordering};
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex};
-use embedded_graphics::prelude::ContainsPoint;
+use embedded_graphics::prelude::{ContainsPoint, PointsIter};
 use embedded_graphics::{
     Pixel,
     draw_target::DrawTarget,
@@ -26,28 +26,47 @@ pub enum PartitioningError {
     ExistingNotFound,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AreaToFlush {
+    All,
+    Some(Rectangle),
+    None,
+}
+
+impl AreaToFlush {
+    pub fn include(&mut self, other: &Rectangle) {
+        match self {
+            AreaToFlush::All => {}
+            AreaToFlush::None => *self = AreaToFlush::Some(other.clone()),
+            AreaToFlush::Some(rect) => {
+                *self = AreaToFlush::Some(rect.envelope(other));
+            }
+        }
+    }
+}
+
 pub struct DrawTracker {
     is_dirty: AtomicBool,
-    pub dirty_area: Mutex<CriticalSectionRawMutex, Option<Rectangle>>,
+    pub dirty_area: Mutex<CriticalSectionRawMutex, AreaToFlush>,
 }
 
 impl DrawTracker {
     pub const fn new() -> Self {
         Self {
             is_dirty: AtomicBool::new(false),
-            dirty_area: Mutex::new(None),
+            dirty_area: Mutex::new(AreaToFlush::None),
         }
     }
 
-    pub async fn take_dirty_area(&self) -> Option<Rectangle> {
+    pub async fn take_dirty_area(&self) -> AreaToFlush {
         if self.is_dirty.load(Ordering::Acquire) {
             let mut guard = self.dirty_area.lock().await;
-            let result = guard.clone().unwrap();
-            *guard = None;
+            let area = guard.clone();
+            *guard = AreaToFlush::None;
             self.is_dirty.store(false, Ordering::Release);
-            Some(result)
+            area
         } else {
-            None
+            AreaToFlush::None
         }
     }
 }
@@ -201,10 +220,10 @@ where
     where
         I: ::core::iter::IntoIterator<Item = Pixel<Self::Color>>,
     {
-        let mut dirty_area: Option<Rectangle> = self.draw_tracker.dirty_area.lock().await.clone();
         let whole_buffer: &mut [B] =
             // Safety: we check that every index is within our owned slice
             unsafe { core::slice::from_raw_parts_mut(self.buffer, self.buffer_len) };
+        let mut has_drawn = false;
         pixels
             .into_iter()
             .map(|pixel| Pixel(pixel.0 + self.area.top_left, pixel.1))
@@ -213,30 +232,34 @@ where
                 let buffer_index = D::calculate_buffer_index(p.0, self.parent_size);
                 if self.contains(p.0) {
                     D::set_pixel(&mut whole_buffer[buffer_index], p);
-
-                    dirty_area = match dirty_area {
-                        None => Some(Rectangle::with_center(p.0, Size::default())),
-                        Some(previous_area) => Some(
-                            previous_area.envelope(&Rectangle::with_center(p.0, Size::default())),
-                        ),
-                    };
+                    has_drawn = true;
                 }
             });
-        if let Some(dirty_area) = dirty_area {
+        if has_drawn {
             self.draw_tracker.is_dirty.store(true, Ordering::Relaxed);
-            let mut guard = self.draw_tracker.dirty_area.lock().await;
-            *guard = Some(dirty_area);
+            *self.draw_tracker.dirty_area.lock().await = AreaToFlush::All;
         }
         Ok(())
+    }
+
+    async fn fill_contiguous<I>(&mut self, area: &Rectangle, colors: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Self::Color>,
+    {
+        self.draw_tracker.dirty_area.lock().await.include(area);
+        self.draw_iter(
+            area.points()
+                .zip(colors)
+                .map(|(pos, color)| Pixel(pos, color)),
+        )
+        .await
     }
 
     // Make sure to remove the offset from the Rectangle to be cleared,
     // draw_iter adds it again
     async fn clear(&mut self, color: Self::Color) -> Result<(), Self::Error> {
         self.draw_tracker.is_dirty.store(true, Ordering::Relaxed);
-        {
-            *self.draw_tracker.dirty_area.lock().await = Some(self.area);
-        }
+        *self.draw_tracker.dirty_area.lock().await = AreaToFlush::All;
 
         self.fill_solid(&(Rectangle::new(Point::new(0, 0), self.area.size)), color)
             .await

--- a/src/toolkit.rs
+++ b/src/toolkit.rs
@@ -4,7 +4,7 @@ use core::future::Future;
 use core::pin::Pin;
 use embassy_executor::Spawner;
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, channel::Channel, mutex::Mutex};
-use embassy_time::Timer;
+use embassy_time::{Duration, Timer};
 use embedded_graphics::{
     geometry::{Point, Size},
     primitives::Rectangle,
@@ -15,6 +15,7 @@ use shared_display_core::{
     DisplayPartition, DrawTracker, PartitioningError, SharableBufferedDisplay,
 };
 
+const FLUSH_INTERVAL: Duration = Duration::from_millis(20);
 const MAX_APPS: usize = 8;
 const EVENT_QUEUE_SIZE: usize = MAX_APPS;
 pub static EVENTS: Channel<CriticalSectionRawMutex, ResizeEvent, EVENT_QUEUE_SIZE> = Channel::new();
@@ -159,7 +160,7 @@ where
                     }
                 }
             }
-            Timer::after_millis(200).await;
+            Timer::after(FLUSH_INTERVAL).await;
         }
     }
 }

--- a/tests/flush_dirty_only.rs
+++ b/tests/flush_dirty_only.rs
@@ -1,11 +1,7 @@
 use core::convert::Infallible;
 use embedded_graphics::{
-    Pixel,
-    draw_target::DrawTarget,
-    geometry::Point,
-    pixelcolor::BinaryColor,
-    prelude::*,
-    primitives::{PrimitiveStyle, Rectangle},
+    Pixel, draw_target::DrawTarget, geometry::Point, pixelcolor::BinaryColor, prelude::*,
+    primitives::Rectangle,
 };
 use shared_display_core::{AreaToFlush, DrawTracker, PartitioningError, SharableBufferedDisplay};
 
@@ -83,15 +79,16 @@ async fn flush_dirty_only() -> Result<(), PartitioningError> {
     assert_eq!(DRAW_TRACKERS[0].take_dirty_area().await, AreaToFlush::All,);
     assert_eq!(DRAW_TRACKERS[0].take_dirty_area().await, AreaToFlush::None);
 
-    let rect = Rectangle::new(Point::new(0, 0), Size::new(2, 2));
-    rect.into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
-        .draw(&mut right_display)
+    let rect = Rectangle::new(Point::new(0, 1), Size::new(2, 1));
+    right_display
+        .fill_solid(&rect, BinaryColor::On)
         .await
         .unwrap();
-    assert_eq!(DRAW_TRACKERS[1].take_dirty_area().await, AreaToFlush::All,);
+    assert_eq!(
+        DRAW_TRACKERS[1].take_dirty_area().await,
+        AreaToFlush::Some(rect),
+    );
     assert_eq!(DRAW_TRACKERS[1].take_dirty_area().await, AreaToFlush::None);
-
-    //TODO: add test for AreaToFlush::Some(rect)
 
     Ok(())
 }

--- a/tests/flush_dirty_only.rs
+++ b/tests/flush_dirty_only.rs
@@ -7,7 +7,7 @@ use embedded_graphics::{
     prelude::*,
     primitives::{PrimitiveStyle, Rectangle},
 };
-use shared_display_core::{DrawTracker, PartitioningError, SharableBufferedDisplay};
+use shared_display_core::{AreaToFlush, DrawTracker, PartitioningError, SharableBufferedDisplay};
 
 const DISP_WIDTH: usize = 16;
 const DISP_HEIGHT: usize = 4;
@@ -80,22 +80,18 @@ async fn flush_dirty_only() -> Result<(), PartitioningError> {
     let mut right_display = d.new_partition(right_area, &DRAW_TRACKERS[1]).unwrap();
 
     left_display.clear(BinaryColor::Off).await.unwrap();
-    assert_eq!(
-        DRAW_TRACKERS[0].take_dirty_area().await.unwrap(),
-        Rectangle::new_at_origin(Size::new(8, 2))
-    );
-    assert_eq!(DRAW_TRACKERS[0].take_dirty_area().await, None);
+    assert_eq!(DRAW_TRACKERS[0].take_dirty_area().await, AreaToFlush::All,);
+    assert_eq!(DRAW_TRACKERS[0].take_dirty_area().await, AreaToFlush::None);
 
     let rect = Rectangle::new(Point::new(0, 0), Size::new(2, 2));
     rect.into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
         .draw(&mut right_display)
         .await
         .unwrap();
-    assert_eq!(
-        DRAW_TRACKERS[1].take_dirty_area().await.unwrap(),
-        Rectangle::new(right_partition_origin, Size::new(2, 2))
-    );
-    assert_eq!(DRAW_TRACKERS[1].take_dirty_area().await, None);
+    assert_eq!(DRAW_TRACKERS[1].take_dirty_area().await, AreaToFlush::All,);
+    assert_eq!(DRAW_TRACKERS[1].take_dirty_area().await, AreaToFlush::None);
+
+    //TODO: add test for AreaToFlush::Some(rect)
 
     Ok(())
 }


### PR DESCRIPTION
Previously, keeping track of the dirty area for flushing would involve computing the new area for every pixel drawn.
To make this less expensive, these changes adapt the `DrawTracker` to only record the exact dirty area inside a partition if a whole rectangle is drawn in one function call (`fill_contiguous`). If an iterator of pixels is drawn, it just sets the entire partition to dirty to avoid paying the computational cost for every pixel.

Some rudimentary benchmarking showed a clear performance improvement for these changes.